### PR TITLE
"View on IPFS gateway" opens link twice#2350

### DIFF
--- a/src/webui/open-external.js
+++ b/src/webui/open-external.js
@@ -2,18 +2,30 @@ const { app, shell } = require('electron')
 
 module.exports = function () {
   app.on('web-contents-created', (_, contents) => {
+    let linkOpened = false; // Initialize a flag to track whether the link has been opened
+
     contents.on('will-navigate', (event, url) => {
       const parsedUrl = new URL(url)
 
       if (parsedUrl.origin !== 'webui://-') {
-        event.preventDefault()
-        shell.openExternal(url)
+        event.preventDefault();
+
+        // Check if the link has already been opened
+        if (!linkOpened) {
+          shell.openExternal(url);
+          linkOpened = true; // Set the flag to true
+        }
       }
     })
 
     contents.on('new-window', (event, url) => {
-      event.preventDefault()
-      shell.openExternal(url)
+      event.preventDefault();
+
+      // Check if the link has already been opened
+      if (!linkOpened) {
+        shell.openExternal(url);
+        linkOpened = true; // Set the flag to true
+      }
     })
   })
 }


### PR DESCRIPTION
fixed "View on IPFS gateway" opens link twice #2350

The issue you're encountering with the code is likely due to the fact that you are attaching event listeners for both the 'will-navigate' and 'new-window' events on the same 'contents' object. This can result in the 'shell.openExternal(url)' code being executed twice when a link is clicked.

To fix this issue and ensure that links are opened only once, you can use a flag to keep track of whether the link has already been opened. Here's an updated version.

By using the "linkOpened" flag, you ensure that the link is opened only once, even if both 'will-navigate' and 'new-window' events are triggered. This should resolve the issue of links being opened twice.